### PR TITLE
BaSP-MR-105: add trainer form alert fixed

### DIFF
--- a/src/redux/trainers/thunks.js
+++ b/src/redux/trainers/thunks.js
@@ -78,13 +78,25 @@ export const addTrainer = (request) => {
       });
       const responseJson = await response.json();
       if (responseJson.error) {
+        if (responseJson.message.errors) {
+          throw new Error(responseJson.message.message);
+        }
         throw new Error(responseJson.message);
       } else {
         const { data, message } = responseJson;
         dispatch(addTrainerSuccess({ data, message }));
       }
     } catch (error) {
-      dispatch(addTrainerError(error.message));
+      if (error.message.length > 70) {
+        dispatch(
+          addTrainerError(
+            error.message.substring(26, 32) +
+              error.message.substring(error.message.length - 48, error.message.length)
+          )
+        );
+      } else {
+        dispatch(addTrainerError(error.message));
+      }
     }
   };
 };


### PR DESCRIPTION
**Changes:**
- Conditional when throw and catch the error _added_ in **redux/trainers/thunks.js**
- Now when the email length is more than 30 the modal shows it corresponding message

**Ticket 105**
https://trello.com/c/SJia5F4T/105-bug-trainers-add-trainer