### PR TITLE
BaSP-MR-177: repeat email input.

### DIFF
--- a/src/Components/Signs/SignUp/index.jsx
+++ b/src/Components/Signs/SignUp/index.jsx
@@ -108,7 +108,7 @@ const MemberSingUp = () => {
                 />
               </fieldset>
               <fieldset className={styles.fieldset}>
-                <Input
+                {/*<Input
                   labelText="Repeat Email"
                   className={styles.input}
                   name={'email'}
@@ -116,7 +116,7 @@ const MemberSingUp = () => {
                   placeholder="example@example.com"
                   error={errors.email?.message}
                   register={register}
-                />
+  />*/}
               </fieldset>
               <fieldset className={styles.fieldset}>
                 <Input


### PR DESCRIPTION
In this PR it was decided to remove the repeat email field for two main reasons: The first one is that the field was not a field in itself, but only had a different label than the email and received the same value as the email, so it was validating itself. At the same time, being able to edit the email from the member flow as well as from the admin flow, if there is a typing error when registering, it could be easily solved (especially taking into account that an account activation is not used from the email).